### PR TITLE
Implement Streamlit interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+result.csv
+process.log
+output/
+logs/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Utility to extract episode tables from Word documents into a single CSV file.
 
 ## Usage
 
-1. Put all `.doc` and `.docx` files inside a directory.
+1. Create a folder for your source files, for example `input_docs`, and place
+   all `.doc` and `.docx` files there.
 2. Run the extractor specifying that directory:
    
    ```bash
@@ -24,7 +25,8 @@ streamlit run app.py
 
 The interface lets you choose the folder with Word documents, specify the
 output CSV path and the number of files to process, then shows progress and a
-download link.
+download link. By default it looks for `input_docs` and writes to
+`output/result.csv` relative to the project directory.
 
 Dependencies:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # archive
-From Word to CSV
+
+Utility to extract episode tables from Word documents into a single CSV file.
+
+## Usage
+
+1. Put all `.doc` and `.docx` files inside a directory.
+2. Run the extractor specifying that directory:
+   
+   ```bash
+   python extract_word.py /path/to/folder -o result.csv
+   ```
+
+Each run processes up to 500 files (configurable with `--limit`) and appends
+rows to the CSV. A log file `process.log` lists processed files and any errors.
+
+### Web interface
+
+Run a small GUI with Streamlit:
+
+```bash
+streamlit run app.py
+```
+
+The interface lets you choose the folder with Word documents, specify the
+output CSV path and the number of files to process, then shows progress and a
+download link.
+
+Dependencies:
+
+- `python-docx`
+- `pywin32` (only on Windows, for `.doc` files)

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Utility to extract episode tables from Word documents into a single CSV file.
 
 Each run processes up to 500 files (configurable with `--limit`) and appends
 rows to the CSV. For every document only one meaningful table row longer than
-100 characters is kept. The resulting CSV has three columns: `source_id`,
-`date` and `description`. A log file `process.log` lists processed files and
-any errors.
+100 characters is kept. If several files share the same `source_id`, only the
+first one is written to the result. Descriptions are split into sentences on
+separate lines within the cell. The resulting CSV has three columns:
+`source_id`, `date` and `description`. A log file `process.log` lists processed
+files and any errors.
 
 ### Web interface
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ Utility to extract episode tables from Word documents into a single CSV file.
    ```
 
 Each run processes up to 500 files (configurable with `--limit`) and appends
-rows to the CSV. For every document only one meaningful table row longer than
-100 characters is kept. If several files share the same `source_id`, only the
-first one is written to the result. Descriptions are split into sentences on
-separate lines within the cell. The resulting CSV has three columns:
-`source_id`, `date` and `description`. A log file `process.log` lists processed
-files and any errors.
+rows to the CSV. All tables are scanned and every non-empty row becomes a
+record. If a row starts with empty leading cells it is treated as a continuation
+of the previous description and appended to it with a newline. Multi-line text
+inside description cells is preserved. If several files share the same
+`source_id`, only the first one is written to the result. The resulting CSV has
+three columns: `source_id`, `date` and `description`. A log file `process.log`
+lists processed files and any errors.
 
 ### Web interface
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ Utility to extract episode tables from Word documents into a single CSV file.
    python extract_word.py /path/to/folder -o result.csv
    ```
 
-Each run processes up to 500 files (configurable with `--limit`) and appends
-rows to the CSV. All tables are scanned and every non-empty row becomes a
-record. If a row starts with empty leading cells it is treated as a continuation
-of the previous description and appended to it with a newline. Multi-line text
-inside description cells is preserved. If several files share the same
-`source_id`, only the first one is written to the result. The resulting CSV has
-three columns: `source_id`, `date` and `description`. A log file `process.log`
-lists processed files and any errors.
+Each run processes up to 500 files (configurable with `--limit`) and appends a
+single line per document. All meaningful rows from tables are merged into one
+`description` field. Continuation rows and multi-line cells are joined with
+newlines and repetitive technical phrases are removed. If several files share
+the same `source_id`, only the first one is written to the result. The resulting
+CSV has three columns: `source_id`, `date` and `description`. A log file
+`process.log` lists processed files and any errors.
 
 ### Web interface
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Utility to extract episode tables from Word documents into a single CSV file.
    ```
 
 Each run processes up to 500 files (configurable with `--limit`) and appends
-rows to the CSV. A log file `process.log` lists processed files and any errors.
+rows to the CSV. The resulting file has three columns: `source_id`, `date`
+and `description`. A log file `process.log` lists processed files and any
+errors.
 
 ### Web interface
 
@@ -28,7 +30,14 @@ output CSV path and the number of files to process, then shows progress and a
 download link. By default it looks for `input_docs` and writes to
 `output/result.csv` relative to the project directory.
 
-Dependencies:
+### Requirements
 
+- Python 3.9+
 - `python-docx`
 - `pywin32` (only on Windows, for `.doc` files)
+- Microsoft Word installed if `.doc` support is needed.
+
+The script uses COM automation to convert `.doc` files to `.docx`. If you see
+an error like `-2147221008, 'Не был произведен вызов CoInitialize.'`, ensure
+that `pywin32` is installed and the program is run on Windows with Microsoft
+Word available. The utility initializes COM automatically when converting.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Utility to extract episode tables from Word documents into a single CSV file.
    ```
 
 Each run processes up to 500 files (configurable with `--limit`) and appends
-rows to the CSV. The resulting file has three columns: `source_id`, `date`
-and `description`. A log file `process.log` lists processed files and any
-errors.
+rows to the CSV. For every document only one meaningful table row longer than
+100 characters is kept. The resulting CSV has three columns: `source_id`,
+`date` and `description`. A log file `process.log` lists processed files and
+any errors.
 
 ### Web interface
 

--- a/app.py
+++ b/app.py
@@ -5,17 +5,22 @@ import pandas as pd
 
 st.title('Парсер монтажных листов')
 
-input_dir = st.text_input('Путь к папке с Word-документами', 'input_docs')
-output_name = st.text_input('Имя выходного CSV', 'output/result.csv')
+input_dir = st.text_input(
+    'Путь к папке с Word-документами', str(Path('input_docs').resolve())
+)
+output_name = st.text_input(
+    'Имя выходного CSV', str(Path('output/result.csv').resolve())
+)
 limit = st.number_input('Лимит на количество файлов', min_value=1, max_value=500, value=500, step=1)
 
 if st.button('Запустить обработку'):
-    path = Path(input_dir)
+    path = Path(input_dir).expanduser()
     if not path.exists():
         st.error('Указанная папка не существует')
     else:
-        output_path = Path(output_name)
+        output_path = Path(output_name).expanduser()
         output_path.parent.mkdir(parents=True, exist_ok=True)
+        st.write(f'Сохраняем результат в: {output_path.resolve()}')
         processed, rows, log = process_documents(path, output_path, limit)
         st.success(f'Файлов обработано: {processed}, строк получено: {rows}')
         with open(output_path, 'rb') as f:

--- a/app.py
+++ b/app.py
@@ -1,0 +1,26 @@
+import streamlit as st
+from pathlib import Path
+from extract_word import process_documents
+import pandas as pd
+
+st.title('Парсер монтажных листов')
+
+input_dir = st.text_input('Путь к папке с Word-документами', 'input_docs')
+output_name = st.text_input('Имя выходного CSV', 'output/result.csv')
+limit = st.number_input('Лимит на количество файлов', min_value=1, max_value=500, value=500, step=1)
+
+if st.button('Запустить обработку'):
+    path = Path(input_dir)
+    if not path.exists():
+        st.error('Указанная папка не существует')
+    else:
+        output_path = Path(output_name)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        processed, rows, log = process_documents(path, output_path, limit)
+        st.success(f'Файлов обработано: {processed}, строк получено: {rows}')
+        with open(output_path, 'rb') as f:
+            st.download_button('Скачать CSV', f.read(), file_name=output_path.name, mime='text/csv')
+        if st.checkbox('Показать результат'):
+            df = pd.read_csv(output_path, delimiter=';')
+            st.dataframe(df)
+        st.text_area('Лог', '\n'.join(log), height=200)

--- a/extract_word.py
+++ b/extract_word.py
@@ -15,6 +15,7 @@ TRANSLIT_MAP = {
     'Д': 'D',
     'Ф': 'F',
     'Н': 'H',
+    'В': 'V',
 }
 
 EXCLUDE_WORDS = [
@@ -25,26 +26,47 @@ EXCLUDE_WORDS = [
 ]
 
 JUNK_PHRASES = ['обрыв', 'таймкод сбит']
+TECH_PREFIXES = ['НОМЕР', 'ТАЙМК', 'НАЧАЛ', 'КОНЕЦ', 'TIME']
 
 TIME_PATTERN = re.compile(r'\b\d{1,2}[:.]\d{2}[:.]\d{2}\b')
 DATE_PATTERN = re.compile(r'\b\d{1,2}[./]\d{1,2}[./]\d{4}\b')
 
 
 def normalize_source_id(filename: str) -> str:
+    """Return normalized cassette ID based on filename without regex."""
     name = Path(filename).stem.upper()
     for word in EXCLUDE_WORDS:
-        name = re.sub(word.upper(), '', name)
-    name = name.replace('_', '').replace(' ', '')
+        name = name.replace(word.upper(), ' ')
+
+    name = name.replace('_', ' ')
+    cleaned = ''.join(ch if ch.isalnum() or ch in '- ' else ' ' for ch in name)
+    parts = [p for p in cleaned.split() if p]
+
+    letters = ''
+    digits = ''
+    for part in parts:
+        part_letters = ''.join(c for c in part if c.isalpha())
+        part_digits = ''.join(c for c in part if c.isdigit() or c == '-')
+        if not letters and part_letters:
+            letters = part_letters
+            if part_digits:
+                digits = part_digits
+                break
+        elif letters and not digits and part_digits:
+            digits = part_digits
+            break
+
+    if not letters and parts:
+        first = parts[0]
+        letters = ''.join(c for c in first if c.isalpha())
+        digits = ''.join(c for c in first if c.isdigit() or c == '-')
+
     for cyr, lat in TRANSLIT_MAP.items():
-        name = name.replace(cyr, lat)
-    match = re.match(r'([A-Z]+)(.*)', name)
-    if match:
-        letters, rest = match.groups()
-        rest = rest.lstrip('-')
-        if rest and not rest.startswith('-'):
-            rest = '-' + rest
-        return f"{letters}{rest}"
-    return name
+        letters = letters.replace(cyr, lat)
+
+    letters = letters.strip('-')
+    digits = digits.strip('-')
+    return f"{letters}-{digits}".strip('-')
 
 
 def convert_doc_to_docx(path: Path) -> Path:
@@ -65,7 +87,7 @@ def convert_doc_to_docx(path: Path) -> Path:
 
 
 def parse_docx_tables(path: Path):
-    """Return date string and descriptions from all tables."""
+    """Return date string and one meaningful description from tables."""
     from docx import Document  # imported here to avoid dependency when unused
     from docx.oxml.table import CT_Tbl
     from docx.oxml.text.paragraph import CT_P
@@ -96,9 +118,13 @@ def parse_docx_tables(path: Path):
                         cleaned = cleaned.replace(junk, '').strip()
                     if cleaned and not cleaned.isdigit():
                         desc_parts.append(cleaned)
-                desc = ' '.join(desc_parts)
+                desc = ' '.join(desc_parts).strip()
                 if desc:
-                    records.append(desc)
+                    clean_line = ' '.join(desc.split())
+                    if (len(clean_line) > 100 and not any(
+                            clean_line.upper().startswith(p) for p in TECH_PREFIXES)):
+                        records.append(clean_line)
+                        return date, records
     return date, records
 
 

--- a/extract_word.py
+++ b/extract_word.py
@@ -94,7 +94,12 @@ def convert_doc_to_docx(path: Path) -> Path:
 
 
 def parse_docx_tables(path: Path):
-    """Return date string and one meaningful description from tables."""
+    """Return date and list of descriptions from all tables.
+
+    Multi-line text is preserved. Rows that start with empty leading cells are
+    considered a continuation of the previous description and appended with a
+    newline.
+    """
     from docx import Document  # imported here to avoid dependency when unused
     from docx.oxml.table import CT_Tbl
     from docx.oxml.text.paragraph import CT_P
@@ -106,32 +111,34 @@ def parse_docx_tables(path: Path):
     records: list[str] = []
 
     for element in doc.element.body.iterchildren():
-        if isinstance(element, CT_P):
-            if date is None:
-                paragraph = Paragraph(element, doc)
-                match = DATE_PATTERN.search(paragraph.text)
-                if match:
-                    date = match.group().replace('/', '.')
+        if isinstance(element, CT_P) and date is None:
+            paragraph = Paragraph(element, doc)
+            match = DATE_PATTERN.search(paragraph.text)
+            if match:
+                date = match.group().replace('/', '.')
         elif isinstance(element, CT_Tbl):
             table = Table(element, doc)
-            if not table.rows:
-                continue
             for row in table.rows:
                 cells = [cell.text.strip() for cell in row.cells]
-                desc_parts = []
-                for text in cells:
-                    cleaned = TIME_PATTERN.sub('', text).strip()
+                if not any(cells):
+                    continue
+                cleaned = [TIME_PATTERN.sub('', c) for c in cells]
+                for i in range(len(cleaned)):
                     for junk in JUNK_PHRASES:
-                        cleaned = cleaned.replace(junk, '').strip()
-                    if cleaned and not cleaned.isdigit():
-                        desc_parts.append(cleaned)
+                        cleaned[i] = cleaned[i].replace(junk, '')
+                    cleaned[i] = cleaned[i].strip()
+
+                is_cont = all(not cleaned[i] for i in range(min(3, len(cleaned))))
+                desc_cells = cleaned[3:] if len(cleaned) > 3 else cleaned
+                desc_parts = [c for c in desc_cells if c and not c.isdigit()]
+                if not desc_parts:
+                    continue
                 desc = ' '.join(desc_parts).strip()
-                if desc:
-                    clean_line = ' '.join(desc.split())
-                    if (len(clean_line) > 100 and not any(
-                            clean_line.upper().startswith(p) for p in TECH_PREFIXES)):
-                        records.append(format_description(clean_line))
-                        return date, records
+                if is_cont and records:
+                    records[-1] += "\n" + desc
+                else:
+                    records.append(desc)
+
     return date, records
 
 

--- a/extract_word.py
+++ b/extract_word.py
@@ -15,7 +15,6 @@ TRANSLIT_MAP = {
     'Д': 'D',
     'Ф': 'F',
     'Н': 'H',
-    'В': 'V',
 }
 
 EXCLUDE_WORDS = [
@@ -30,6 +29,11 @@ TECH_PREFIXES = ['НОМЕР', 'ТАЙМК', 'НАЧАЛ', 'КОНЕЦ', 'TIME']
 
 TIME_PATTERN = re.compile(r'\b\d{1,2}[:.]\d{2}[:.]\d{2}\b')
 DATE_PATTERN = re.compile(r'\b\d{1,2}[./]\d{1,2}[./]\d{4}\b')
+
+
+def format_description(text: str) -> str:
+    """Return text with each sentence on a new line."""
+    return re.sub(r'(?<=[.!?])\s+', '\n', text).strip()
 
 
 def normalize_source_id(filename: str) -> str:
@@ -63,6 +67,9 @@ def normalize_source_id(filename: str) -> str:
 
     for cyr, lat in TRANSLIT_MAP.items():
         letters = letters.replace(cyr, lat)
+
+    if letters.startswith('В'):
+        letters = 'B' + letters[1:]
 
     letters = letters.strip('-')
     digits = digits.strip('-')
@@ -123,7 +130,7 @@ def parse_docx_tables(path: Path):
                     clean_line = ' '.join(desc.split())
                     if (len(clean_line) > 100 and not any(
                             clean_line.upper().startswith(p) for p in TECH_PREFIXES)):
-                        records.append(clean_line)
+                        records.append(format_description(clean_line))
                         return date, records
     return date, records
 
@@ -159,10 +166,14 @@ def process_documents(input_dir: Path, output_csv: Path, limit: int = 500):
     processed = 0
     row_count = 0
     log_lines: list[str] = []
+    seen_ids: set[str] = set()
 
     for file in files:
         try:
             source_id = normalize_source_id(file.name)
+            if source_id in seen_ids:
+                log_lines.append(f'Skipped duplicate {file.name}')
+                continue
             target = file
             if file.suffix.lower() == '.doc':
                 target = convert_doc_to_docx(file)
@@ -173,6 +184,7 @@ def process_documents(input_dir: Path, output_csv: Path, limit: int = 500):
             row_count += len(descriptions)
             rows = [(source_id, date or '', desc) for desc in descriptions]
             write_csv(output_csv, rows)
+            seen_ids.add(source_id)
             log_lines.append(f'Processed {file.name}')
         except Exception as exc:  # pragma: no cover - execution errors
             log_lines.append(f'{file.name}: {exc}')

--- a/extract_word.py
+++ b/extract_word.py
@@ -1,0 +1,161 @@
+import argparse
+import csv
+import re
+from pathlib import Path
+
+try:
+    import win32com.client  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    win32com = None
+
+
+TRANSLIT_MAP = {
+    'АП': 'AP',
+    'Д': 'D',
+    'Ф': 'F',
+    'Н': 'H',
+}
+
+EXCLUDE_WORDS = [
+    'кассета',
+    'обращение',
+    'копия',
+    'монтажный лист',
+]
+
+JUNK_PHRASES = ['обрыв', 'таймкод сбит']
+
+TIME_PATTERN = re.compile(r'\b\d{1,2}[:.]\d{2}[:.]\d{2}\b')
+
+
+def normalize_source_id(filename: str) -> str:
+    name = Path(filename).stem.upper()
+    for word in EXCLUDE_WORDS:
+        name = re.sub(word.upper(), '', name)
+    name = name.replace('_', '').replace(' ', '')
+    for cyr, lat in TRANSLIT_MAP.items():
+        name = name.replace(cyr, lat)
+    match = re.match(r'([A-Z]+)(.*)', name)
+    if match:
+        letters, rest = match.groups()
+        rest = rest.lstrip('-')
+        if rest and not rest.startswith('-'):
+            rest = '-' + rest
+        return f"{letters}{rest}"
+    return name
+
+
+def convert_doc_to_docx(path: Path) -> Path:
+    if win32com is None:
+        raise RuntimeError('win32com is required to handle .doc files')
+    word = win32com.client.Dispatch('Word.Application')
+    word.Visible = False
+    doc = word.Documents.Open(str(path))
+    docx_path = str(path) + 'x'
+    doc.SaveAs(docx_path, FileFormat=16)
+    doc.Close()
+    word.Quit()
+    return Path(docx_path)
+
+
+def parse_docx_tables(path: Path):
+    from docx import Document  # imported here to avoid dependency when unused
+    doc = Document(str(path))
+    records = []
+    for table in doc.tables:
+        if not table.rows:
+            continue
+        for row in table.rows:
+            cells = [cell.text.strip() for cell in row.cells]
+            times = []
+            desc_parts = []
+            for text in cells:
+                found = TIME_PATTERN.findall(text)
+                if found:
+                    times.extend(found)
+                cleaned = TIME_PATTERN.sub('', text).strip()
+                if cleaned and not cleaned.isdigit():
+                    desc_parts.append(cleaned)
+            if not times:
+                continue
+            if len(times) >= 2:
+                tc = f"{times[0]} – {times[1]}"
+            else:
+                tc = times[0]
+            desc = ' '.join(desc_parts)
+            for junk in JUNK_PHRASES:
+                desc = desc.replace(junk, '').strip()
+            if not desc:
+                continue
+            records.append((tc, desc))
+    return records
+
+
+def write_csv(path: Path, rows):
+    exists = path.exists()
+    with open(path, 'a', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f, delimiter=';')
+        if not exists:
+            writer.writerow(['source_id', 'timecode', 'description'])
+        for r in rows:
+            writer.writerow(r)
+
+
+def process_documents(input_dir: Path, output_csv: Path, limit: int = 500):
+    """Process Word documents and save episodes to CSV.
+
+    Parameters
+    ----------
+    input_dir: Path
+        Directory with Word files.
+    output_csv: Path
+        Destination CSV path.
+    limit: int
+        Maximum number of files to process.
+
+    Returns
+    -------
+    tuple[int, int, list[str]]
+        Files processed, rows written and log lines.
+    """
+    files = sorted(input_dir.glob('*.doc*'))[:limit]
+    processed = 0
+    row_count = 0
+    log_lines: list[str] = []
+
+    for file in files:
+        try:
+            source_id = normalize_source_id(file.name)
+            target = file
+            if file.suffix.lower() == '.doc':
+                target = convert_doc_to_docx(file)
+            rows = parse_docx_tables(target)
+            if not rows:
+                continue
+            processed += 1
+            row_count += len(rows)
+            rows = [(source_id, tc, desc) for tc, desc in rows]
+            write_csv(output_csv, rows)
+            log_lines.append(f'Processed {file.name}')
+        except Exception as exc:  # pragma: no cover - execution errors
+            log_lines.append(f'{file.name}: {exc}')
+
+    return processed, row_count, log_lines
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Extract episode tables from Word docs into CSV')
+    parser.add_argument('input_dir', help='Directory with Word files')
+    parser.add_argument('-o', '--output', default='result.csv', help='Output CSV path')
+    parser.add_argument('--limit', type=int, default=500, help='Files to process in one run')
+    parser.add_argument('--log-file', default='process.log', help='Path to log file')
+    args = parser.parse_args()
+
+    processed, rows, log_lines = process_documents(Path(args.input_dir), Path(args.output), args.limit)
+    with open(args.log_file, 'w', encoding='utf-8') as lf:
+        lf.write('\n'.join(log_lines))
+    print(f'Files processed: {processed}, rows written: {rows}')
+
+
+if __name__ == '__main__':
+    main()

--- a/extract_word.py
+++ b/extract_word.py
@@ -24,7 +24,23 @@ EXCLUDE_WORDS = [
     'монтажный лист',
 ]
 
-JUNK_PHRASES = ['обрыв', 'таймкод сбит']
+JUNK_PHRASES = [
+    'обрыв',
+    'таймкод сбит',
+    'техническая пауза',
+    'черный фон',
+    'чёрный фон',
+    'стоп-кадр',
+    'стоп кадр',
+    'тип плана',
+    'содержание (описание) плана',
+    'титры',
+    'монолог',
+    'разговор',
+    'песни',
+    'субтитры',
+    'музыка',
+]
 TECH_PREFIXES = ['НОМЕР', 'ТАЙМК', 'НАЧАЛ', 'КОНЕЦ', 'TIME']
 
 TIME_PATTERN = re.compile(r'\b\d{1,2}[:.]\d{2}[:.]\d{2}\b')
@@ -94,11 +110,12 @@ def convert_doc_to_docx(path: Path) -> Path:
 
 
 def parse_docx_tables(path: Path):
-    """Return date and list of descriptions from all tables.
+    """Return the first date and a combined description from all tables.
 
-    Multi-line text is preserved. Rows that start with empty leading cells are
-    considered a continuation of the previous description and appended with a
-    newline.
+    Multi-line text is preserved. Rows starting with empty leading cells are
+    treated as continuations of the previous description. Technical or
+    repetitive lines are removed. All descriptions are joined with a newline so
+    that one document yields a single block of text.
     """
     from docx import Document  # imported here to avoid dependency when unused
     from docx.oxml.table import CT_Tbl
@@ -109,6 +126,7 @@ def parse_docx_tables(path: Path):
     doc = Document(str(path))
     date = None
     records: list[str] = []
+    unique_lines: set[str] = set()
 
     for element in doc.element.body.iterchildren():
         if isinstance(element, CT_P) and date is None:
@@ -134,12 +152,20 @@ def parse_docx_tables(path: Path):
                 if not desc_parts:
                     continue
                 desc = ' '.join(desc_parts).strip()
+                if not desc:
+                    continue
+                line_lower = desc.lower()
+                if any(ph in line_lower for ph in JUNK_PHRASES):
+                    continue
                 if is_cont and records:
                     records[-1] += "\n" + desc
                 else:
-                    records.append(desc)
+                    if desc not in unique_lines:
+                        records.append(desc)
+                        unique_lines.add(desc)
 
-    return date, records
+    combined = "\n".join(records).strip()
+    return date, combined
 
 
 def write_csv(path: Path, rows):
@@ -184,13 +210,12 @@ def process_documents(input_dir: Path, output_csv: Path, limit: int = 500):
             target = file
             if file.suffix.lower() == '.doc':
                 target = convert_doc_to_docx(file)
-            date, descriptions = parse_docx_tables(target)
-            if not descriptions:
+            date, description = parse_docx_tables(target)
+            if not description:
                 continue
             processed += 1
-            row_count += len(descriptions)
-            rows = [(source_id, date or '', desc) for desc in descriptions]
-            write_csv(output_csv, rows)
+            row_count += 1
+            write_csv(output_csv, [(source_id, date or '', description)])
             seen_ids.add(source_id)
             log_lines.append(f'Processed {file.name}')
         except Exception as exc:  # pragma: no cover - execution errors

--- a/extract_word.py
+++ b/extract_word.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 try:
     import win32com.client  # type: ignore
+    import pythoncom  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     win32com = None
 
@@ -26,6 +27,7 @@ EXCLUDE_WORDS = [
 JUNK_PHRASES = ['обрыв', 'таймкод сбит']
 
 TIME_PATTERN = re.compile(r'\b\d{1,2}[:.]\d{2}[:.]\d{2}\b')
+DATE_PATTERN = re.compile(r'\b\d{1,2}[./]\d{1,2}[./]\d{4}\b')
 
 
 def normalize_source_id(filename: str) -> str:
@@ -48,47 +50,56 @@ def normalize_source_id(filename: str) -> str:
 def convert_doc_to_docx(path: Path) -> Path:
     if win32com is None:
         raise RuntimeError('win32com is required to handle .doc files')
-    word = win32com.client.Dispatch('Word.Application')
-    word.Visible = False
-    doc = word.Documents.Open(str(path))
-    docx_path = str(path) + 'x'
-    doc.SaveAs(docx_path, FileFormat=16)
-    doc.Close()
-    word.Quit()
-    return Path(docx_path)
+    pythoncom.CoInitialize()
+    try:
+        word = win32com.client.Dispatch('Word.Application')
+        word.Visible = False
+        doc = word.Documents.Open(str(path))
+        docx_path = str(path) + 'x'
+        doc.SaveAs(docx_path, FileFormat=16)
+        doc.Close()
+        word.Quit()
+        return Path(docx_path)
+    finally:
+        pythoncom.CoUninitialize()
 
 
 def parse_docx_tables(path: Path):
+    """Return date string and descriptions from all tables."""
     from docx import Document  # imported here to avoid dependency when unused
+    from docx.oxml.table import CT_Tbl
+    from docx.oxml.text.paragraph import CT_P
+    from docx.table import Table
+    from docx.text.paragraph import Paragraph
+
     doc = Document(str(path))
-    records = []
-    for table in doc.tables:
-        if not table.rows:
-            continue
-        for row in table.rows:
-            cells = [cell.text.strip() for cell in row.cells]
-            times = []
-            desc_parts = []
-            for text in cells:
-                found = TIME_PATTERN.findall(text)
-                if found:
-                    times.extend(found)
-                cleaned = TIME_PATTERN.sub('', text).strip()
-                if cleaned and not cleaned.isdigit():
-                    desc_parts.append(cleaned)
-            if not times:
+    date = None
+    records: list[str] = []
+
+    for element in doc.element.body.iterchildren():
+        if isinstance(element, CT_P):
+            if date is None:
+                paragraph = Paragraph(element, doc)
+                match = DATE_PATTERN.search(paragraph.text)
+                if match:
+                    date = match.group().replace('/', '.')
+        elif isinstance(element, CT_Tbl):
+            table = Table(element, doc)
+            if not table.rows:
                 continue
-            if len(times) >= 2:
-                tc = f"{times[0]} – {times[1]}"
-            else:
-                tc = times[0]
-            desc = ' '.join(desc_parts)
-            for junk in JUNK_PHRASES:
-                desc = desc.replace(junk, '').strip()
-            if not desc:
-                continue
-            records.append((tc, desc))
-    return records
+            for row in table.rows:
+                cells = [cell.text.strip() for cell in row.cells]
+                desc_parts = []
+                for text in cells:
+                    cleaned = TIME_PATTERN.sub('', text).strip()
+                    for junk in JUNK_PHRASES:
+                        cleaned = cleaned.replace(junk, '').strip()
+                    if cleaned and not cleaned.isdigit():
+                        desc_parts.append(cleaned)
+                desc = ' '.join(desc_parts)
+                if desc:
+                    records.append(desc)
+    return date, records
 
 
 def write_csv(path: Path, rows):
@@ -96,13 +107,13 @@ def write_csv(path: Path, rows):
     with open(path, 'a', newline='', encoding='utf-8') as f:
         writer = csv.writer(f, delimiter=';')
         if not exists:
-            writer.writerow(['source_id', 'timecode', 'description'])
+            writer.writerow(['source_id', 'date', 'description'])
         for r in rows:
             writer.writerow(r)
 
 
 def process_documents(input_dir: Path, output_csv: Path, limit: int = 500):
-    """Process Word documents and save episodes to CSV.
+    """Process Word documents and save episode descriptions to CSV.
 
     Parameters
     ----------
@@ -129,12 +140,12 @@ def process_documents(input_dir: Path, output_csv: Path, limit: int = 500):
             target = file
             if file.suffix.lower() == '.doc':
                 target = convert_doc_to_docx(file)
-            rows = parse_docx_tables(target)
-            if not rows:
+            date, descriptions = parse_docx_tables(target)
+            if not descriptions:
                 continue
             processed += 1
-            row_count += len(rows)
-            rows = [(source_id, tc, desc) for tc, desc in rows]
+            row_count += len(descriptions)
+            rows = [(source_id, date or '', desc) for desc in descriptions]
             write_csv(output_csv, rows)
             log_lines.append(f'Processed {file.name}')
         except Exception as exc:  # pragma: no cover - execution errors

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -9,6 +9,9 @@ from extract_word import normalize_source_id, process_documents
 def test_normalize_source_id():
     assert normalize_source_id('Д64-217.doc') == 'D-64-217'
     assert normalize_source_id('АП 90-341.docx') == 'AP-90-341'
+    assert normalize_source_id('Кассета АП 60-072 БРИФИНГ РОГОВА.doc') == 'AP-60-072'
+    assert normalize_source_id('В 010.doc') == 'V-010'
+    assert normalize_source_id('Д124-086 Пресс-конференция.doc') == 'D-124-086'
 
 
 def test_process_documents_empty(tmp_path):

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from extract_word import normalize_source_id, process_documents
+
+
+def test_normalize_source_id():
+    assert normalize_source_id('Д64-217.doc') == 'D-64-217'
+    assert normalize_source_id('АП 90-341.docx') == 'AP-90-341'
+
+
+def test_process_documents_empty(tmp_path):
+    out = tmp_path / 'out.csv'
+    processed, rows, _ = process_documents(tmp_path, out, limit=10)
+    assert processed == 0
+    assert rows == 0
+    assert not out.exists()

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -10,7 +10,7 @@ def test_normalize_source_id():
     assert normalize_source_id('Д64-217.doc') == 'D-64-217'
     assert normalize_source_id('АП 90-341.docx') == 'AP-90-341'
     assert normalize_source_id('Кассета АП 60-072 БРИФИНГ РОГОВА.doc') == 'AP-60-072'
-    assert normalize_source_id('В 010.doc') == 'V-010'
+    assert normalize_source_id('В 010.doc') == 'B-010'
     assert normalize_source_id('Д124-086 Пресс-конференция.doc') == 'D-124-086'
 
 


### PR DESCRIPTION
## Summary
- refactor extractor to expose `process_documents`
- add `app.py` Streamlit GUI
- document web interface in README
- ignore output and logs folders
- test empty directory processing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bbf59da4883278598e2a3cdc8e85d